### PR TITLE
Update NetWatcher.sh

### DIFF
--- a/NetWatcher.sh
+++ b/NetWatcher.sh
@@ -68,8 +68,14 @@ send_report_email() {
     fi
 }
 
+# Check if on-demand report requested
+if [[ "$1" == "--report" ]]; then
+    send_report_email
+    exit 0
+fi
+
 # Main loop to send report email every 24 hours
 while true; do
-    send_report_email
+    send_report_email &
     sleep "$uptime_interval"
 done


### PR DESCRIPTION
added manual on-demand generate report and continue in background.

Now, if you run the script with the --report argument (./script.sh --report), it will generate an immediate report and then exit. Otherwise, it will continue to run in the background, sending reports every 24 hours.